### PR TITLE
ci: remove registry-url from setup-node for OIDC publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm ci
       - name: Build


### PR DESCRIPTION
## Summary
- Remove `registry-url` from `setup-node` — it causes `setup-node` to inject `GITHUB_TOKEN` as `NODE_AUTH_TOKEN`, which overrides OIDC trusted publisher auth and causes 404 on npm publish.

## Test plan
- [ ] Re-run the failed v0.13.2 publish workflow after merge