### PR TITLE
ci: add workflow_dispatch trigger to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: publish
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to allow manually re-running the publish workflow from the Actions tab, useful when a release publish fails and needs to be retried after a fix.